### PR TITLE
Respect `amount` when listing releases

### DIFF
--- a/github.go
+++ b/github.go
@@ -55,7 +55,7 @@ type (
 					HasNextPage githubv4.Boolean
 				}
 				Nodes []ghRelease
-			} `graphql:"releases(first: $limit, after: $releaseCursor, orderBy: {field:CREATED_AT, direction: DESC})"`
+			} `graphql:"releases(first: 10, after: $releaseCursor, orderBy: {field:CREATED_AT, direction: DESC})"`
 		} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 	}
 )
@@ -129,7 +129,6 @@ func (g *GithubLocator) ListReleases(ctx context.Context, amount int) (_ []Relea
 		"repositoryOwner": githubv4.String(g.owner),
 		"repositoryName":  githubv4.String(g.repo),
 		"releaseCursor":   (*githubv4.String)(nil), // Null after argument to get first page.
-		"limit":           githubv4.Int(amount),
 	}
 
 	var query queryRepoReleases
@@ -169,6 +168,7 @@ func (g *GithubLocator) ListReleases(ctx context.Context, amount int) (_ []Relea
 			}
 		}
 
+		// If we do not have enough releases, we will continue to fetch the next page
 		if len(releases) < amount && query.Repository.Releases.PageInfo.HasNextPage {
 			variables["releaseCursor"] = githubv4.NewString(query.Repository.Releases.PageInfo.EndCursor)
 			continue

--- a/github.go
+++ b/github.go
@@ -169,7 +169,7 @@ func (g *GithubLocator) ListReleases(ctx context.Context, amount int) (_ []Relea
 			}
 		}
 
-		if query.Repository.Releases.PageInfo.HasNextPage {
+		if len(releases) < amount && query.Repository.Releases.PageInfo.HasNextPage {
 			variables["releaseCursor"] = githubv4.NewString(query.Repository.Releases.PageInfo.EndCursor)
 			continue
 		}


### PR DESCRIPTION
## Summary
This PR updates `ListReleases` to respect the `amount` value.

## Implementation
- Before this change, `ListReleases` would keep looping until the `EndCursor` even when the `amount` was set to 1 and the release had already been found. I have now updated the conditional check that determines whether the loop should continue or break.
- I also think the purpose of `amount` might be misinterpreted as it is used as the `first` parameter in the GraphQL release query. This means `amount` is the number of releases that GitHub should return per query (more like per page). Instead, the `amount` is the maximum number of releases that should be returned after filtering. To correct this, I have set a fixed value of `10` for the `first` variable. This also now makes finding a single release faster since GitHub will now return 10 release nodes per query.